### PR TITLE
Fix input csv creation procedure

### DIFF
--- a/OMMatlab.m
+++ b/OMMatlab.m
@@ -569,7 +569,11 @@ classdef OMMatlab < handle
             obj.csvfile = replace(fullfile(obj.mattempdir,[char(obj.modelname),'.csv']),'\','/');
             fileID = fopen(obj.csvfile,"w");
             %disp(strjoin(fieldnames(obj.inputlist),","));
-            fprintf(fileID,['time,',strjoin(fieldnames(obj.inputlist),","),',end\n']);
+            inputStrings=fieldnames(obj.inputlist);
+            for i = 1:numel(inputStrings)
+                inputStrings_Modified{i,1} = regexprep(inputStrings{i}, '_([^_]*)_', '[$1]');
+            end
+            fprintf(fileID,['time,',strjoin(inputStrings_Modified,","),',end\n']);
             %csvdata = obj.inputlist;
             fields=fieldnames(obj.inputlist);
             %time=strings(1,length(csvdata));


### PR DESCRIPTION
The names of array inputs have to be in the form of "a[i]" inside the csv file. Therefore, the current name formatting of input name list for the array type elements (i.e., "a_i_") has been fixed in the csv creation step.